### PR TITLE
update secrets for npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,7 @@ jobs:
 
       - name: Release SDKs
         env:
-          FERN_NPM_TOKEN: ${{ secrets.FERN_NPM_TOKEN }}
-          FERN_MAVEN_USERNAME: ${{ secrets.FERN_MAVEN_USERNAME }}
-          FERN_MAVEN_TOKEN: ${{ secrets.FERN_MAVEN_TOKEN }}
-          FERN_POSTMAN_API_KEY: ${{ secrets.FERN_POSTMAN_API_KEY }}
-          FERN_POSTMAN_WORKSPACE_ID: ${{ secrets.FERN_POSTMAN_WORKSPACE_ID }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: | 
           fern generate --group external --version ${{ github.ref_name }} --log-level debug

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -6,6 +6,6 @@ groups:
         output:
           location: npm
           package-name: '@fern-api/rivet'
-          token: ${FERN_NPM_TOKEN}
+          token: ${NPM_TOKEN}
         github:
-          repository: fern-rivet/rivet-node
+          repository: rivet-gg/rivet-node


### PR DESCRIPTION
Before you can start using fern's automation to change APIs and automatically generate SDKs we need to configure a couple things: 
(1) We need to configure the coordinate of the TS SDK. 
(2) We need to set a couple secrets, NPM Token for publishing and Fern Token so that fern can give you access to run `fern generate`. 